### PR TITLE
Fix Boost.Python shared DLL linking and update CI actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python  ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         architecture: ['x64']
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Build script for PyAlembic (Alembic Python bindings) on Windows, outputting `.whl` packages.
+
+## Build
+
+```powershell
+.\build.ps1 -PythonRoot "C:\Program Files\Python311" | Tee-Object build.log
+```
+
+Stages can be skipped individually: `-SkipBoost`, `-SkipImath`, `-SkipAlembic`, `-SkipPackaging`, `-SkipInstall`.
+
+Output: `dist/*.whl`
+
+## CI
+
+`.github/workflows/build.yml` — manual trigger, builds Python 3.9–3.13 on Windows x64. Set `runReleaseAction` to create a GitHub Release.
+
+## Key Notes
+
+- Imath is pinned to commit `84f9a67` to avoid a build error introduced by PR #361. Updating Imath requires verifying PyAlembic still builds.
+- `setup.py` dynamically reads metadata from the cloned `alembic/setup.py` at build time.
+- Boost.Python must be linked as a shared DLL (not static) because PyImath and Alembic both use the same Boost.Python type registry, which cannot be shared across DLL boundaries with static linking. The wheel bundles `boost_python*.dll` alongside the other DLLs.
+- `BOOST_ALL_NO_LIB` is passed as a compile flag to disable Boost's Windows auto-link feature, ensuring the explicitly-specified shared library is used instead of the auto-linked one.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ To build PyAlembic, follow these steps:
 3. Run the `build.ps1` script with the `-PythonRoot` option, specifying the path to your Python installation. For example:
 
     ```powershell
-    PS C:\builds\pyalembic-windows-buildscript> .\build.ps1 -PythonRoot "$env:USERPROFILE\.pyenv\pyenv-win\versions\3.10.8" | Tee-Object build.log
+    PS C:\builds\pyalembic-windows-buildscript> .\build.ps1 -PythonRoot "C:\Program Files\Python314" | Tee-Object build.log
     ```
 
 A .whl file will be output to the `dist` directory.
+
+## Pre-built Wheels
+
+Pre-built wheels are available on the [Releases](https://github.com/ugai/pyalembic-windows-buildscript/releases) page.
+
+Note: the wheels bundle third-party libraries (Alembic, Imath, Boost) under their respective licenses, which differ from the CC0 license of this repository.
 
 ## Usage
 

--- a/build.ps1
+++ b/build.ps1
@@ -16,23 +16,26 @@ $ProgressPreference = 'SilentlyContinue'
 
 $PythonRoot = $PythonRoot -replace "\\", "/" # replace backslashes
 $PythonExe = "$PythonRoot/Python.exe"
+$PythonVersion = & $PythonExe -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')"
 
 $BoostZipName = $BoostZipUrl.Split("/")[-1]
 $BoostZipDestName = "boost"
+$BoostAbsPath = (Join-Path $PWD $BoostZipDestName) -replace "\\", "/"
+$ImathAbsPath = (Join-Path $PWD "Imath/_installed") -replace "\\", "/"
 
 # Build boost
 if (-Not $SkipBoost) {
     # Download zip
     if (!(Test-Path $BoostZipName)) {
         Write-Output "Download: '$BoostZipUrl'"
-        Invoke-WebRequest -Uri $BoostZipUrl -OutFile $BoostZipName   
+        Invoke-WebRequest -Uri $BoostZipUrl -OutFile $BoostZipName
     }
-    
+
     # Extract zip
     if (!(Test-Path $BoostZipDestName)) {
         Write-Output "Unzip: '$BoostZipName'"
         Expand-Archive -Path $BoostZipName -DestinationPath . -Force
-    
+
         Write-Output "Move: '$BoostZipExtractedName' -> '$BoostZipDestName'"
         Move-Item $BoostZipExtractedName $BoostZipDestName
     }
@@ -40,11 +43,17 @@ if (-Not $SkipBoost) {
     Push-Location boost
 
     try {
+        # Temporarily unset NoDefaultCurrentDirectoryInExePath so that
+        # Boost's bootstrap batch files can find each other via relative paths.
+        $origNoDirExe = $env:NoDefaultCurrentDirectoryInExePath
+        $env:NoDefaultCurrentDirectoryInExePath = $null
+
         .\bootstrap.bat
-        Write-Output "using python : : $PythonRoot ;" > user-config.jam
-        .\b2 -a address-model=64 --variant=release --with-python --user-config=user-config.jam
+        "using python : : $PythonRoot ;" | Out-File -Encoding ascii user-config.jam
+        .\b2 -a address-model=64 --variant=release link=shared --with-python --user-config=user-config.jam
     }
     finally {
+        $env:NoDefaultCurrentDirectoryInExePath = $origNoDirExe
         Pop-Location
     }
 }
@@ -61,6 +70,8 @@ if (-Not $SkipImath) {
         #   https://github.com/AcademySoftwareFoundation/Imath/pull/361/commits/e79adb7e9e2876243b67a59828b3651f4e187781
         #
         # Checkout the previous commit to avoid the error.
+        # TODO: Remove this pin once Imath releases a version that includes PR #507 and the
+        # PyImath COMPONENT fix (see issue #395).
         git checkout 84f9a674802f6c3197bd478c9b40399f451fecb3
     }
     finally {
@@ -73,7 +84,7 @@ if (-Not $SkipImath) {
     Push-Location Imath/build
 
     try {
-        cmake .. -DPython_EXECUTABLE="$PythonExe" -DPython3_EXECUTABLE="$PythonExe" -DPYTHON=ON -DBoost_ROOT="../../$BoostZipDestName" -DCMAKE_INSTALL_PREFIX="../_installed"
+        cmake .. -DPython_EXECUTABLE="$PythonExe" -DPython3_EXECUTABLE="$PythonExe" -DPYTHON=ON -DPYBIND11=OFF -DBoost_ROOT="$BoostAbsPath" -DBoost_NO_BOOST_CMAKE=OFF -DBoost_USE_STATIC_LIBS=OFF -DPYIMATH_BOOST_PY_COMPONENT="python$PythonVersion" -DCMAKE_CXX_FLAGS="/bigobj /DBOOST_ALL_NO_LIB" -DCMAKE_INSTALL_PREFIX="../_installed"
         cmake --build . --config Release
         cmake --install .
     }
@@ -85,11 +96,17 @@ if (-Not $SkipImath) {
 # Build alembic
 if (-Not $SkipAlembic) {
     git clone https://github.com/alembic/alembic
+
+    # Patch: specify versioned Boost python component (e.g. python311) so
+    # FindBoost can locate the correct library.
+    $pyAlembicCMake = "alembic/python/PyAlembic/CMakeLists.txt"
+    (Get-Content $pyAlembicCMake) -replace 'COMPONENTS python\)', "COMPONENTS python$PythonVersion)" | Set-Content $pyAlembicCMake
+
     if (!(Test-Path alembic/build)) { mkdir alembic/build }
     Push-Location alembic/build
 
     try {
-        cmake .. -DUSE_PYALEMBIC=ON -DCMAKE_CXX_FLAGS="/wd4251" -DImath_DIR="../Imath/_installed/lib/cmake/Imath" -DPython3_EXECUTABLE="$PythonExe" -DBoost_ROOT="../../$BoostZipDestName" -DCMAKE_INSTALL_PREFIX="../_installed" -DALEMBIC_PYTHON_INSTALL_DIR="../_installed/lib/site-packages"
+        cmake .. -DUSE_PYALEMBIC=ON -DUSE_STATIC_BOOST=OFF -DCMAKE_CXX_FLAGS="/wd4251 /DBOOST_ALL_NO_LIB" -DImath_DIR="$ImathAbsPath/lib/cmake/Imath" -DPython_EXECUTABLE="$PythonExe" -DPython3_EXECUTABLE="$PythonExe" -DBoost_ROOT="$BoostAbsPath" -DCMAKE_INSTALL_PREFIX="../_installed" -DALEMBIC_PYTHON_INSTALL_DIR="../_installed/lib/site-packages"
         cmake --build . --config Release
         cmake --install .
     }

--- a/build.ps1
+++ b/build.ps1
@@ -6,13 +6,23 @@ param (
     [switch]$SkipImath,
     [switch]$SkipAlembic,
     [switch]$SkipPackaging,
-    [switch]$SkipInstall
+    [switch]$SkipInstall,
+    [bool]$CleanCC = $true
 )
 
 Write-Output "Start ($(Get-Date))"
 Write-Output "PythonRoot: '$PythonRoot'"
 
 $ProgressPreference = 'SilentlyContinue'
+
+# Clear CC/CXX environment variables that may interfere with the build.
+# These are not needed as CMake and Boost detect MSVC automatically.
+if ($CleanCC) {
+    $origCC = $env:CC
+    $origCXX = $env:CXX
+    $env:CC = $null
+    $env:CXX = $null
+}
 
 $PythonRoot = $PythonRoot -replace "\\", "/" # replace backslashes
 $PythonExe = "$PythonRoot/Python.exe"
@@ -128,6 +138,11 @@ if (-Not $SkipInstall) {
 
     # Test module import
     & $PythonExe -c "import alembic"
+}
+
+if ($CleanCC) {
+    $env:CC = $origCC
+    $env:CXX = $origCXX
 }
 
 Write-Output "End ($(Get-Date))"

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,17 @@ class CustomInstallCommand(install):
             # *.pyd files
             "alembic/_installed/lib/site-packages/*.pyd",
             "Imath/_installed/lib/site-packages/*.pyd",
+            "Imath/_installed/Lib/site-packages/*.pyd",
             # *.dll files
-            "boost/stage/lib/*.dll",
-            "alembic/_installed/lib/*.dll",
+            "boost/stage/lib/boost_python*.dll",
+            "alembic/_installed/bin/*.dll",
             "Imath/_installed/bin/*.dll",
         ]
 
         for pattern in GLOB_PATTERNS:
             for rel_path in glob.glob(pattern):
+                if "-gd-" in rel_path:  # skip debug Boost DLLs
+                    continue
                 print(f"file copy: '{rel_path}' -> '{self.install_lib}'")
                 shutil.copy(rel_path, self.install_lib)
 


### PR DESCRIPTION
## Summary

- Fix Boost.Python linking to use shared DLL instead of static, enabling cross-DLL type registry sharing between PyImath and Alembic
- Build Boost with `link=shared` only (static was unused and wasted build time)
- Add `BOOST_ALL_NO_LIB` to disable Windows auto-link and explicitly control which library is used
- Bundle `boost_python*.dll`, `imath.pyd`, and other required DLLs in the wheel
- Add Python 3.14 to CI matrix
- Update GitHub Actions to Node.js 24-compatible versions (`checkout@v4`, `setup-python@v5`)

## Background

PyImath and Alembic both use Boost.Python's type registry. Static linking gives each DLL its own isolated registry, causing `import imath` to fail with `'NoneType' object has no attribute '__dict__'`. Linking both against a single shared `boost_python*.dll` fixes this.

## Test plan

- [x] CI build passed for Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 on Windows x64
